### PR TITLE
replaceOne and unit test

### DIFF
--- a/src/operations/__tests__/replaceOne.test.ts
+++ b/src/operations/__tests__/replaceOne.test.ts
@@ -1,0 +1,55 @@
+import { wrapReplaceOne } from "../replaceOne";
+import { mockCollection, stripLogLines } from "../../../test/test-utils";
+
+const mockReplaceOne = jest.fn();
+const mockedDocumentCount = 100;
+
+const filter = { name: "Jimmy" };
+const expectedLogCall = ["replaceOne", "100 documents matching", filter];
+
+describe("replaceOne", () => {
+  const wrappedReplaceOne = wrapReplaceOne(mockReplaceOne);
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe("dry mode", () => {
+    const collection = mockCollection(true, mockedDocumentCount);
+
+    it("should log correctly and return a dummy result", async () => {
+      const result = await wrappedReplaceOne.call(collection, filter);
+
+      // Ensure stub response is correct and that real call was not made
+      expect(result).toEqual({
+        acknowledged: true,
+        replacedCount: 1,
+      });
+      expect(mockReplaceOne).not.toHaveBeenCalled();
+
+      // Ensure logger was called with correct arguments
+      expect(collection.__migmong_log).toHaveBeenCalledTimes(1);
+      const strippedArgs = collection.__migmong_log.mock.calls.map(stripLogLines);
+
+      expect(strippedArgs[0]).toEqual(expectedLogCall);
+    });
+  });
+
+  describe("live mode", () => {
+    const collection = mockCollection(false, mockedDocumentCount);
+
+    it("should log correctly and return the real result", async () => {
+      const mockedReturnValue = "Doesn't matter";
+      mockReplaceOne.mockReturnValue(mockedReturnValue);
+      const result = await wrappedReplaceOne.call(collection, filter);
+
+      // Ensure stub response is correct and that real call was not made
+      expect(result).toEqual(mockedReturnValue);
+      expect(mockReplaceOne).toHaveBeenCalledTimes(1);
+
+      // Ensure logger was called with correct arguments
+      expect(collection.__migmong_log).toHaveBeenCalledTimes(1);
+      const strippedArgs = collection.__migmong_log.mock.calls.map(stripLogLines);
+
+      expect(strippedArgs[0]).toEqual(expectedLogCall);
+    });
+  });
+});

--- a/src/operations/replaceOne.ts
+++ b/src/operations/replaceOne.ts
@@ -1,0 +1,29 @@
+import { Collection, Document, Filter, ReplaceOptions, UpdateResult } from "mongodb";
+import { WrappedCollection } from "../types";
+import { logOperation } from "../logger";
+
+export function wrapReplaceOne<TSchema extends Document = Document>(fn: Collection["replaceOne"]) {
+  return async function replaceOne(
+    this: WrappedCollection<TSchema>,
+    filter: Filter<TSchema>,
+    options: ReplaceOptions
+  ): Promise<Document | UpdateResult> {
+    const count = await this.countDocuments(filter);
+
+    const { dry } = this.__migmong_options;
+    logOperation(this.__migmong_log, "replaceOne", count, filter);
+
+    if (dry) {
+      // return what the mongo driver would in real life
+      return {
+        acknowledged: true,
+        modifiedCount: 1,
+        upsertedId: null,
+        upsertedCount: 0,
+        matchedCount: 1,
+      };
+    }
+
+    return fn(filter, options);
+  };
+}


### PR DESCRIPTION
Will refactor the old integration tests for operations into unit tests for the logging, and ensure that the operations themselves are tested as part of the overall runner integration test